### PR TITLE
Issue where non-existing service account is used in the secret validation hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Issue where non-existing service account is used in the secret validation hook [#871](https://github.com/signalfx/splunk-otel-collector-chart/pull/871),[#878](https://github.com/signalfx/splunk-otel-collector-chart/pull/878)
+
 ## [0.82.0] - 2023-08-02
 
 This Splunk OpenTelemetry Collector for Kubernetes release adopts the [Splunk OpenTelemetry Collector v0.82.0](https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.82.0).

--- a/examples/secret-validation/rendered_manifests/secret-splunk-validation-hook.yaml
+++ b/examples/secret-validation/rendered_manifests/secret-splunk-validation-hook.yaml
@@ -1,7 +1,6 @@
 ---
 # Source: splunk-otel-collector/templates/secret-splunk-validation-hook.yaml
-# Helm hook validating that custom secret provided by user has all the required
-# fields.
+# Helm hook that validates a custom secret provided by the user has all the required fields.
 apiVersion: v1
 kind: Pod
 metadata:
@@ -16,7 +15,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  serviceAccountName: splunk-collector
+  # A short-lived service account managed by this chart. See: https://helm.sh/docs/topics/charts_hooks/#hooks-and-the-release-lifecycle
+  serviceAccountName: default-splunk-otel-collector-validate-secret
   restartPolicy: Never
   containers:
   - name: validate-secret

--- a/examples/secret-validation/rendered_manifests/secret-splunk-validation-service-account.yaml
+++ b/examples/secret-validation/rendered_manifests/secret-splunk-validation-service-account.yaml
@@ -1,0 +1,21 @@
+---
+# Source: splunk-otel-collector/templates/secret-splunk-validation-service-account.yaml
+# Service account that is used by validation. Only exists during pre-install or pre-upgrade phases.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: splunk-collector-validate-secret
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.82.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.82.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.82.0
+    release: default
+    heritage: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-1"

--- a/examples/secret-validation/secret-validation-values.yaml
+++ b/examples/secret-validation/secret-validation-values.yaml
@@ -11,6 +11,5 @@ secret:
   create: false
   name: splunk-otel-collector
 serviceAccount:
-  # Assuming serviceAccount doesn't exist yet and is not necessary to access the secret
   create: true
   name: splunk-collector

--- a/helm-charts/splunk-otel-collector/templates/secret-splunk-validation-hook.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-splunk-validation-hook.yaml
@@ -1,6 +1,5 @@
 {{- if and (not .Values.secret.create) (.Values.secret.validateSecret) }}
-# Helm hook validating that custom secret provided by user has all the required
-# fields.
+# Helm hook that validates a custom secret provided by the user has all the required fields.
 apiVersion: v1
 kind: Pod
 metadata:
@@ -11,7 +10,13 @@ metadata:
     "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  {{- if .Values.serviceAccount.create }}
+  # A short-lived service account managed by this chart. See: https://helm.sh/docs/topics/charts_hooks/#hooks-and-the-release-lifecycle
+  serviceAccountName: {{ template "splunk-otel-collector.fullname" . }}-validate-secret
+  {{- else }}
+  # A custom service account provided by the user.
   serviceAccountName: {{ template "splunk-otel-collector.serviceAccountName" . }}
+  {{- end }}
   restartPolicy: Never
   containers:
   - name: validate-secret

--- a/helm-charts/splunk-otel-collector/templates/secret-splunk-validation-service-account.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-splunk-validation-service-account.yaml
@@ -1,0 +1,7 @@
+{{- if and (not .Values.secret.create) (.Values.secret.validateSecret) (.Values.serviceAccount.create) }}
+# Service account that is used by validation. Only exists during pre-install or pre-upgrade phases.
+{{- $hookAnnotations := dict "helm.sh/hook" "pre-install,pre-upgrade" "helm.sh/hook-weight" "-1" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
+{{- $customValues := dict "nameSuffix" "-validate-secret" "extraAnnotations" $hookAnnotations }}
+{{- $common := dict "context" . "values" $customValues }}
+{{- include "splunk-otel-collector.serviceAccountTemplate" $common | nindent 0 }}
+{{- end }}

--- a/helm-charts/splunk-otel-collector/templates/serviceAccount.yaml
+++ b/helm-charts/splunk-otel-collector/templates/serviceAccount.yaml
@@ -1,22 +1,5 @@
 {{- if .Values.serviceAccount.create }}
-apiVersion: v1
-{{- if .Values.image.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end }}
-kind: ServiceAccount
-metadata:
-  name: {{ template "splunk-otel-collector.serviceAccountName" . }}
-  labels:
-    {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
-    app: {{ template "splunk-otel-collector.name" . }}
-    chart: {{ template "splunk-otel-collector.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  {{- if .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
-  {{- end }}
+{{- $customValues := dict "nameSuffix" "" "extraAnnotations" list }}
+{{- $common := dict "context" . "values" $customValues }}
+{{- include "splunk-otel-collector.serviceAccountTemplate" $common | nindent 0 }}
 {{- end }}


### PR DESCRIPTION
Related Issue: https://github.com/signalfx/splunk-otel-collector-chart/issues/780

Description:
- Refactored the service account template to enhance support for the validation hook and any potential future hooks.
- Introduced the serviceAccountTemplate to ensure consistency in the creation of multiple service accounts, especially concerning necessary lifecycle annotations.
  - Note: Resources with Helm Hook annotations don't fall under the typical Helm chart release lifecycle.
- Given that the validation hook exists only during the pre-install and pre-upgrade phases, it necessitates a dedicated service account. This service account should either exist solely within these phases or be an account that the chart doesn't manage.
